### PR TITLE
[DADZ-355] Enable routing to accept tokens to be excluded when finding a suitable route

### DIFF
--- a/cli/commands/quote.ts
+++ b/cli/commands/quote.ts
@@ -39,6 +39,7 @@ export class Quote extends BaseCommand {
       required: false,
       default: false,
     }),
+    excludeTokens: flags.string({ required: false }),
     simulate: flags.boolean({ required: false, default: false }),
   };
 
@@ -67,6 +68,7 @@ export class Quote extends BaseCommand {
       protocols: protocolsStr,
       forceCrossProtocol,
       forceMixedRoutes,
+      excludeTokens,
       simulate,
     } = flags;
 
@@ -86,6 +88,13 @@ export class Quote extends BaseCommand {
         );
       }
     }
+
+    let excludeTokensFromRoute: string[] | undefined = undefined;
+    if (excludeTokens)
+      excludeTokensFromRoute = excludeTokens
+        .toLowerCase()
+        .replace(' ', '')
+        .split(',');
 
     const chainId = ID_TO_CHAIN_ID(chainIdNumb);
 
@@ -142,6 +151,7 @@ export class Quote extends BaseCommand {
           protocols,
           forceCrossProtocol,
           forceMixedRoutes,
+          excludeTokens: excludeTokensFromRoute,
         }
       );
     } else {
@@ -176,6 +186,7 @@ export class Quote extends BaseCommand {
           protocols,
           forceCrossProtocol,
           forceMixedRoutes,
+          excludeTokens: excludeTokensFromRoute,
         }
       );
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@violetprotocol/mauve-smart-order-router",
-  "version": "4.0.10",
+  "version": "4.1.0",
   "description": "Mauve Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@violetprotocol/mauve-smart-order-router",
-  "version": "4.1.0",
+  "version": "4.1.2",
   "description": "Mauve Smart Order Router",
   "main": "build/main/index.js",
   "typings": "build/main/index.d.ts",

--- a/src/routers/alpha-router/alpha-router.ts
+++ b/src/routers/alpha-router/alpha-router.ts
@@ -256,6 +256,10 @@ export type AlphaRouterConfig = {
    */
   forceCrossProtocol: boolean;
   /**
+   * Force the alpha router to exclude specific tokens and their associated pools from the route.
+   */
+  excludeTokens?: string[];
+  /**
    * The minimum percentage of the input token to use for each route in a split route.
    * All routes will have a multiple of this value. For example is distribution percentage is 5,
    * a potential return swap would be:

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -584,9 +584,26 @@ export async function getV3CandidatePools({
 
   const tokenPairs = _.compact(tokenPairsRaw);
 
+  // Only consider pairs where neither tokens are to be excluded.
+  let filteredTokenPairs: [Token, Token, FeeAmount][] = tokenPairs;
+  if (excludeTokens && excludeTokens.length > 0) {
+    filteredTokenPairs = [];
+    for (const [token0, token1, fee] of tokenPairs) {
+      const excludeToken0 = excludeTokens.find((ex) => token0.address == ex);
+      const excludeToken1 = excludeTokens.find((ex) => token1.address == ex);
+
+      console.log(excludeToken0);
+      console.log(excludeToken1);
+
+      if (excludeToken0 || excludeToken1) continue;
+
+      filteredTokenPairs.push([token0, token1, fee]);
+    }
+  }
+
   const beforePoolsLoad = Date.now();
 
-  const poolAccessor = await poolProvider.getPools(tokenPairs);
+  const poolAccessor = await poolProvider.getPools(filteredTokenPairs);
 
   metric.putMetric(
     'V3PoolsLoad',

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -210,12 +210,27 @@ export async function getV3CandidatePools({
     blockNumber,
   });
 
+  // Only consider pools where neither tokens are to be excluded.
+  let prunedPoolsRaw: V3SubgraphPool[] = allPoolsRaw;
+  const excludeTokens = routingConfig.excludeTokens;
+  if (excludeTokens && excludeTokens.length > 0) {
+    prunedPoolsRaw = [];
+    for (const pool of allPoolsRaw) {
+      const excludeToken0 = excludeTokens.find((ex) => pool.token0.id == ex);
+      const excludeToken1 = excludeTokens.find((ex) => pool.token1.id == ex);
+
+      if (excludeToken0 || excludeToken1) continue;
+
+      prunedPoolsRaw.push(pool);
+    }
+  }
+
   log.info(
     { samplePools: allPoolsRaw.slice(0, 3) },
     'Got all pools from V3 subgraph provider'
   );
 
-  const allPools = _.map(allPoolsRaw, (pool) => {
+  const allPools = _.map(prunedPoolsRaw, (pool) => {
     return {
       ...pool,
       token0: {

--- a/src/routers/alpha-router/functions/get-candidate-pools.ts
+++ b/src/routers/alpha-router/functions/get-candidate-pools.ts
@@ -592,9 +592,6 @@ export async function getV3CandidatePools({
       const excludeToken0 = excludeTokens.find((ex) => token0.address == ex);
       const excludeToken1 = excludeTokens.find((ex) => token1.address == ex);
 
-      console.log(excludeToken0);
-      console.log(excludeToken1);
-
       if (excludeToken0 || excludeToken1) continue;
 
       filteredTokenPairs.push([token0, token1, fee]);

--- a/src/routers/router.ts
+++ b/src/routers/router.ts
@@ -14,9 +14,9 @@ import {
 } from '@violetprotocol/mauve-sdk-core';
 import { Route as V2RouteRaw } from '@violetprotocol/mauve-v2-sdk';
 import {
+  MethodParameters as SDKMethodParameters,
   Pool,
   Position,
-  MethodParameters as SDKMethodParameters,
   Route as V3RouteRaw,
 } from '@violetprotocol/mauve-v3-sdk';
 

--- a/test/unit/routers/alpha-router/functions/get-candidate-pools.test.ts
+++ b/test/unit/routers/alpha-router/functions/get-candidate-pools.test.ts
@@ -170,6 +170,34 @@ describe('get candidate pools', () => {
     ).toBeTruthy();
   });
 
+  test('succeeds to get top pools while excluding WETH', async () => {
+    await getV3CandidatePools({
+      tokenIn: USDC,
+      tokenOut: DAI,
+      routeType: TradeType.EXACT_INPUT,
+      routingConfig: {
+        ...ROUTING_CONFIG,
+        v3PoolSelection: {
+          ...ROUTING_CONFIG.v3PoolSelection,
+          topNTokenInOut: 1,
+        },
+        excludeTokens: [WRAPPED_NATIVE_CURRENCY[1].address],
+      },
+      poolProvider: mockV3PoolProvider,
+      subgraphProvider: mockV3SubgraphProvider,
+      tokenProvider: mockTokenProvider,
+      blockedTokenListProvider: mockBlockTokenListProvider,
+      chainId: ChainId.MAINNET,
+    });
+
+    expect(
+      mockV3PoolProvider.getPools.calledWithExactly([
+        [DAI, USDC, FeeAmount.LOW],
+        [DAI, USDT, FeeAmount.LOW],
+      ])
+    ).toBeTruthy();
+  });
+
   test('succeeds to get direct swap pools even if they dont exist in the subgraph', async () => {
     // Mock so that DAI_WETH exists on chain, but not in the subgraph
     const poolsOnSubgraph = [


### PR DESCRIPTION
- feature

Currently all pools are considered when finding routes to tokens, however to support restricted tokens we should be able to specify tokens that should be avoided when finding routes

This PR allows passing a list of token addresses that must be excluded from the route search and return only routes that do not include such tokens.

